### PR TITLE
use Refs instead of introducing new global variables in __init__

### DIFF
--- a/src/backend/GLFW/GLFWBackend.jl
+++ b/src/backend/GLFW/GLFWBackend.jl
@@ -19,18 +19,21 @@ export ImGui_ImplGlfw_InitForOpenGL, ImGui_ImplGlfw_InitForVulkan
 export ImGui_ImplGlfw_Shutdown
 export ImGui_ImplGlfw_NewFrame
 
+const g_Window = Ref{GLFW.Window}()
+const g_ClientApi = Ref(GlfwClientApi_Unknown)
+const g_Time = Ref(0.0)
+const g_MouseJustPressed = [false, false, false, false, false]
+const g_MouseCursors = [GLFW.Cursor(C_NULL) for i = 1:ImGuiMouseCursor_COUNT]
+const g_ImplGlfw_GetClipboardText = Ref(C_NULL)
+const g_ImplGlfw_SetClipboardText = Ref(C_NULL)
+const g_CustomCallbackMousebutton = Ref(C_NULL)
+const g_CustomCallbackScroll = Ref(C_NULL)
+const g_CustomCallbackKey = Ref(C_NULL)
+const g_CustomCallbackChar = Ref(C_NULL)
+
 function __init__()
-    global g_Window = C_NULL
-    global g_ClientApi = GlfwClientApi_Unknown
-    global g_Time = 0.0
-    global g_MouseJustPressed = [false, false, false, false, false]
-    global g_MouseCursors = [GLFW.Cursor(C_NULL) for i = 1:ImGuiMouseCursor_COUNT]
-    global g_ImplGlfw_GetClipboardText = dlsym(dlopen(GLFW.libglfw), :glfwGetClipboardString)
-    global g_ImplGlfw_SetClipboardText = dlsym(dlopen(GLFW.libglfw), :glfwSetClipboardString)
-    global g_CustomCallbackMousebutton = C_NULL
-    global g_CustomCallbackScroll = C_NULL
-    global g_CustomCallbackKey = C_NULL
-    global g_CustomCallbackChar = C_NULL
+    g_ImplGlfw_GetClipboardText[] = dlsym(dlopen(GLFW.libglfw), :glfwGetClipboardString)
+    g_ImplGlfw_SetClipboardText[] = dlsym(dlopen(GLFW.libglfw), :glfwSetClipboardString)
 end
 
 end # module

--- a/src/backend/GLFW/callbacks.jl
+++ b/src/backend/GLFW/callbacks.jl
@@ -1,13 +1,11 @@
 # custom callbacks
-SetCustomMouseButtonCallback(x::Function) = global g_CustomCallbackMousebutton = x
-SetCustomScrollCallback(x::Function) = global g_CustomCallbackScroll = x
-SetCustomKeyCallback(x::Function) = global g_CustomCallbackKey = x
-SetCustomCharCallback(x::Function) = global g_CustomCallbackChar = x
+SetCustomMouseButtonCallback(x::Function) = g_CustomCallbackMousebutton[] = x
+SetCustomScrollCallback(x::Function) = g_CustomCallbackScroll[] = x
+SetCustomKeyCallback(x::Function) = g_CustomCallbackKey[] = x
+SetCustomCharCallback(x::Function) = g_CustomCallbackChar[] = x
 
 function ImGui_ImplGlfw_MouseButtonCallback(window::GLFW.Window, button::GLFW.MouseButton, action::GLFW.Action, mods::Cint)
-    global g_MouseJustPressed
-    global g_CustomCallbackMousebutton
-    g_CustomCallbackMousebutton != C_NULL && g_CustomCallbackMousebutton(window, button, action, mods)
+    g_CustomCallbackMousebutton[] != C_NULL && g_CustomCallbackMousebutton[](window, button, action, mods)
     b = Cint(button)
     if action == GLFW.PRESS && b ≥ 0 && b < length(g_MouseJustPressed)
         g_MouseJustPressed[b+1] = true
@@ -15,16 +13,14 @@ function ImGui_ImplGlfw_MouseButtonCallback(window::GLFW.Window, button::GLFW.Mo
 end
 
 function ImGui_ImplGlfw_ScrollCallback(window::GLFW.Window, xoffset, yoffset)
-    global g_CustomCallbackScroll
-    g_CustomCallbackScroll != C_NULL && g_CustomCallbackScroll(window, xoffset, yoffset)
+    g_CustomCallbackScroll[] != C_NULL && g_CustomCallbackScroll[](window, xoffset, yoffset)
     io = GetIO()
     io.MouseWheelH += Cfloat(xoffset)
     io.MouseWheel += Cfloat(yoffset)
 end
 
 function ImGui_ImplGlfw_KeyCallback(window::GLFW.Window, key, scancode, action, mods)
-    global g_CustomCallbackKey
-    g_CustomCallbackKey != C_NULL && g_CustomCallbackKey(window, key, scancode, action, mods)
+    g_CustomCallbackKey[] != C_NULL && g_CustomCallbackKey[](window, key, scancode, action, mods)
 
     io = GetIO()
     action == GLFW.PRESS && Set_KeysDown(io, key, true)
@@ -37,8 +33,7 @@ function ImGui_ImplGlfw_KeyCallback(window::GLFW.Window, key, scancode, action, 
 end
 
 function ImGui_ImplGlfw_CharCallback(window::GLFW.Window, c)
-    global g_CustomCallbackChar
-    g_CustomCallbackChar != C_NULL && g_CustomCallbackChar(window, c)
+    g_CustomCallbackChar[] != C_NULL && g_CustomCallbackChar[](window, c)
     io = GetIO()
     0 < Cuint(c) < 0x10000 && AddInputCharacter(io, c)
 end

--- a/src/backend/OpenGL/OpenGLBackend.jl
+++ b/src/backend/OpenGL/OpenGLBackend.jl
@@ -14,20 +14,18 @@ export ImGui_ImplOpenGL3_CreateFontsTexture, ImGui_ImplOpenGL3_DestroyFontsTextu
 export ImGui_ImplOpenGL3_CreateDeviceObjects, ImGui_ImplOpenGL3_DestroyDeviceObjects
 export ImGui_ImplOpenGL3_CreateImageTexture, ImGui_ImplOpenGL3_UpdateImageTexture, ImGui_ImplOpenGL3_DestroyImageTexture
 
-function __init__()
-    global g_GlslVersion = 130
-    global g_FontTextures = GLuint[]
-    global g_ShaderHandle = GLuint(0)
-    global g_VertHandle = GLuint(0)
-    global g_FragHandle = GLuint(0)
-    global g_AttribLocationTex = GLint(0)
-    global g_AttribLocationProjMtx = GLint(0)
-    global g_AttribLocationPosition = GLint(0)
-    global g_AttribLocationUV = GLint(0)
-    global g_AttribLocationColor = GLint(0)
-    global g_VboHandle = GLuint(0)
-    global g_ElementsHandle = GLuint(0)
-    global g_ImageTexture = Dict{Int,GLuint}()
-end
+const g_GlslVersion = Ref(130)
+const g_FontTextures = GLuint[]
+const g_ShaderHandle = Ref(GLuint(0))
+const g_VertHandle = Ref(GLuint(0))
+const g_FragHandle = Ref(GLuint(0))
+const g_AttribLocationTex = Ref(GLint(0))
+const g_AttribLocationProjMtx = Ref(GLint(0))
+const g_AttribLocationPosition = Ref(GLint(0))
+const g_AttribLocationUV = Ref(GLint(0))
+const g_AttribLocationColor = Ref(GLint(0))
+const g_VboHandle = Ref(GLuint(0))
+const g_ElementsHandle = Ref(GLuint(0))
+const g_ImageTexture = Dict{Int,GLuint}()
 
 end # module

--- a/src/backend/OpenGL/impl.jl
+++ b/src/backend/OpenGL/impl.jl
@@ -352,7 +352,7 @@ function ImGui_ImplOpenGL3_CreateDeviceObjects()
     g_AttribLocationProjMtx[] = glGetUniformLocation(g_ShaderHandle[], "ProjMtx")
     g_AttribLocationPosition[] = glGetAttribLocation(g_ShaderHandle[], "Position")
     g_AttribLocationUV[] = glGetAttribLocation(g_ShaderHandle[], "UV")
-    g_AttribLocationColor = glGetAttribLocation(g_ShaderHandle[], "Color")
+    g_AttribLocationColor[] = glGetAttribLocation(g_ShaderHandle[], "Color")
 
     # create buffers
     @c glGenBuffers(1, &(g_VboHandle[]))

--- a/src/backend/OpenGL/impl.jl
+++ b/src/backend/OpenGL/impl.jl
@@ -382,7 +382,7 @@ function ImGui_ImplOpenGL3_DestroyDeviceObjects()
     g_FragHandle[] != 0 && glDeleteShader(g_FragHandle[])
     g_FragHandle[] = 0
 
-    g_ShaderHandle[] != 0 && glDeleteProgram(g_ShaderHandle[]),F
+    g_ShaderHandle[] != 0 && glDeleteProgram(g_ShaderHandle[])
     g_ShaderHandle[] = 0
 
     ImGui_ImplOpenGL3_DestroyFontsTexture()


### PR DESCRIPTION
I believe this is "best practice" when it comes to variables that need to be filled in by some library after initiation. This should lead to better performance since the types of the variables are known everywhere and they are `const`. 

Note that I have only tried the example on Linux.