### PR TITLE
Restrict LibCImGui.jl compat bounds

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -18,7 +18,7 @@ CSyntax = "0.4"
 ImGuiGLFWBackend = "0.1"
 ImGuiOpenGL2Backend = "0.1"
 ImGuiOpenGLBackend = "0.1"
-LibCImGui = "1.82.2"
+LibCImGui = "~1.82"
 Preferences = "1"
 julia = "1.6"
 


### PR DESCRIPTION
This is so that we don't inadvertently break things while updating all the packages :sweat_smile: If you agree, I think a new patch release could be made for this.