### PR TITLE
Use demo for tests. Fix docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,13 +3,15 @@ on:
   - push
   - pull_request
 jobs:
-  test:
-    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }}
+  loading:
+    name: Loading only - Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         version:
           - '1.6'
+          - '1'
+          - 'nightly'
         os:
           - ubuntu-latest
           - macOS-latest
@@ -20,19 +22,45 @@ jobs:
         exclude:
           - os: macOS-latest
             arch: x86
+          - os: ubuntu-latest # covered in "tests" job
+            arch: x64
     steps:
       - uses: actions/checkout@v2
-      - run: sudo apt-get install xvfb && Xvfb :99 &
-        if: matrix.os == 'ubuntu-latest'
       - uses: julia-actions/setup-julia@v1
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: julia-actions/julia-buildpkg@latest
-      - uses: julia-actions/julia-runtest@latest
+      - uses: julia-actions/julia-buildpkg@v1
+      - uses: julia-actions/julia-runtest@v1
+      - uses: julia-actions/julia-uploadcodecov@v0.1
         env:
-          DISPLAY: :99
-      - uses: julia-actions/julia-uploadcodecov@latest
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+  tests:
+    name: Tests - Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        version:
+          - '1.6'
+          - '1'
+          - 'nightly'
+        os:
+          - ubuntu-latest
+        arch:
+          - x64
+    steps:
+      - uses: actions/checkout@v2
+      - uses: julia-actions/setup-julia@v1
+        with:
+          version: ${{ matrix.version }}
+          arch: ${{ matrix.arch }}
+      - uses: julia-actions/julia-buildpkg@v1
+      - uses: julia-actions/julia-runtest@v1
+        with:
+          prefix: xvfb-run -a -s '-screen 0 1024x768x24'
+        env:
+          LD_PRELOAD: /usr/lib/x86_64-linux-gnu/libstdc++.so.6
+      - uses: julia-actions/julia-uploadcodecov@v0.1
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
   docs:
@@ -43,7 +71,7 @@ jobs:
       - run: sudo apt-get install xvfb && Xvfb :99 &
       - uses: julia-actions/setup-julia@v1
         with:
-          version: '1.6'
+          version: '1'
       - run: |
           julia --project=docs -e '
             using Pkg

--- a/Project.toml
+++ b/Project.toml
@@ -23,7 +23,8 @@ Preferences = "1"
 julia = "1.6"
 
 [extras]
+Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test"]
+test = ["Printf","Test"]

--- a/demo/demo.jl
+++ b/demo/demo.jl
@@ -63,6 +63,14 @@ ImGuiGLFWBackend.init(glfw_ctx)
 opengl_ctx = ImGuiOpenGLBackend.create_context(glsl_version)
 ImGuiOpenGLBackend.init(opengl_ctx)
 
+# for tests
+if haskey(ENV, "AUTO_CLOSE_DEMO")
+    tsecs = parse(Int, ENV["AUTO_CLOSE_DEMO"])
+    Timer(tsecs) do t
+        glfwSetWindowShouldClose(window, true)
+    end
+end
+
 try
     show_demo_window = true
     show_another_window = false
@@ -112,7 +120,7 @@ try
         glfwGetFramebufferSize(window, width, height)
         display_w = width[]
         display_h = height[]
-        
+
         glViewport(0, 0, display_w, display_h)
         glClearColor(clear_color...)
         glClear(GL_COLOR_BUFFER_BIT)
@@ -120,6 +128,8 @@ try
 
         glfwMakeContextCurrent(window)
         glfwSwapBuffers(window)
+
+        yield() # to allow shutdown timer to run
     end
 catch e
     @error "Error in renderloop!" exception=e

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,3 +1,6 @@
 [deps]
 CImGui = "5d785b6c-b76f-510e-a07c-3070796c7e87"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+
+[compat]
+Documenter = "1"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -4,7 +4,6 @@ using Documenter
 makedocs(;
     modules=[CImGui],
     authors="Yupei Qi <qiyupei@gmail.com>",
-    repo="https://github.com/Gnimuc/CImGui.jl/blob/{commit}{path}#L{line}",
     sitename="CImGui.jl",
     format=Documenter.HTML(;
         prettyurls=get(ENV, "CI", "false") == "true",

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -9,11 +9,12 @@ makedocs(;
         prettyurls=get(ENV, "CI", "false") == "true",
         canonical="https://Gnimuc.github.io/CImGui.jl",
         assets=String[],
+        size_threshold=400000
     ),
     pages=[
        "Introduction" => "index.md",
        "API Reference" => "api.md",
-    ],
+    ]
 )
 
 deploydocs(;

--- a/examples/demo_layout.jl
+++ b/examples/demo_layout.jl
@@ -316,7 +316,7 @@ function ShowDemoWindowLayout()
         if CImGui.ListBoxHeader("List", size)
             CImGui.Selectable("Selected", true)
             CImGui.Selectable("Not Selected", false)
-            CImGui.ListBoxFooter()
+            CImGui.EndListBox()
         end
 
         CImGui.TreePop()

--- a/src/wrapper.jl
+++ b/src/wrapper.jl
@@ -1624,11 +1624,11 @@ If the function return true, you can output elements then call [`EndListBox`](@r
 BeginListBox(label,size=ImVec2(0,0)) = igBeginListBox(label,size)
 
 """
-    ListBoxFooter()
+    EndListBox()
 Terminate the scrolling region.
 
 !!! note
-    Only call `ListBoxFooter()` if [`ListBoxHeader`](@ref) returned true!
+    Only call `EndListBox()` if [`BeginListBox`](@ref) returned true!
 """
 EndListBox() = igEndListBox()
 
@@ -1904,9 +1904,8 @@ GetColumnsCount() = igGetColumnsCount()
 # - 5. Call EndTable()
 """
     BeginTable(str_id, columns_count, flags = ImGuiTableFlags_(0), outer_size = ImVec2(0,0), inner_width = 0.0) -> Bool
-Begin a table entry. 
+Begin a table entry.
 """
-
 BeginTable(str_id, columns_count, flags = ImGuiTableFlags_(0), outer_size = ImVec2(0,0), inner_width = 0.0) = igBeginTable(str_id, columns_count, flags, outer_size, inner_width)
 
 """
@@ -1924,7 +1923,7 @@ TableNextRow(row_flags = ImGuiTableRowFlags_(0), min_row_height = 0.0) = igTable
 """
     TableNextColumn() -> Bool
 Append into the next column (or first column of next row if currently in last column). Return true when column is visible.
-"""                                                                                                                                    
+"""
 TableNextColumn() = igTableNextColumn()
 
 """

--- a/src/wrapper.jl
+++ b/src/wrapper.jl
@@ -2160,7 +2160,6 @@ EndDragDropTarget() = igEndDragDropTarget()
 """
     GetDragDropPayload() -> Ptr{ImGuiPayload}
 Peek directly into the current payload from anywhere. May return C_NULL.
-Use [`IsDataType`](@ref) to test for the payload type.
 
 !!! note "BETA API"
     Missing Demo code. API may evolve.

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,5 +2,12 @@ using CImGui
 using Test
 
 @testset "CImGui.jl" begin
-    # Write your own tests here.
+    # if CI only run if linux given xvfb is available in CI
+    if !haskey(ENV, "CI") || Sys.islinux() && Sys.WORD_SIZE == 64
+        withenv("AUTO_CLOSE_DEMO" => "5") do
+            include(joinpath("..", "demo", "demo.jl"))
+        end
+    else
+        @warn "Tests not run" haskey(ENV, "CI") Sys.islinux() Sys.WORD_SIZE
+    end
 end


### PR DESCRIPTION
This package doesn't work for me on MacOS Silicon due to https://github.com/Gnimuc/CImGui.jl/issues/74 and I was surprised to see there weren't any tests.

This
- Reuses the demo as an easy test to run
- Fixes tests on linux x64 via xvfb
- Updates to handle Documenter v1.0.0 which was being picked up with breakages due to a lack of compat entry for it.
- Fixes broken links in the docs
- Updates one part of an example that was outdated (rest of example not checked)