### PR TITLE
Prepare v1.82.1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "CImGui"
 uuid = "5d785b6c-b76f-510e-a07c-3070796c7e87"
 authors = ["Yupei Qi <qiyupei@gmail.com>"]
-version = "1.82.0"
+version = "1.82.1"
 
 [deps]
 CEnum = "fa961155-64e5-5f13-b03f-caf6b980ea82"
@@ -15,10 +15,10 @@ Preferences = "21216c6a-2e73-6563-6e65-726566657250"
 [compat]
 CEnum = "0.4"
 CSyntax = "0.4"
-ImGuiGLFWBackend = "0.1, 0.2"
+ImGuiGLFWBackend = "0.1"
 ImGuiOpenGL2Backend = "0.1"
-ImGuiOpenGLBackend = "0.1, 0.2"
-LibCImGui = "~1.82, 1"
+ImGuiOpenGLBackend = "0.1"
+LibCImGui = "~1.82"
 Preferences = "1"
 julia = "1.6"
 


### PR DESCRIPTION
This is a patch release that fixes compat bounds for some dependencies, which were previously allowing newer-than-actually-compatible versions. See: https://github.com/Gnimuc/CImGui.jl/issues/100#issuecomment-1740640011

The main change here is to remove the unions from the bounds of ImGuiGLFWBackend.jl, ImGuiOpenGLBackend.jl, and LibCImGui.jl. e.g. `~1.82, 1` for LibCImGui.jl means that the allowed versions would be `[1.82 - 1.83) union [1 - 2)` (if I read the [docs](https://pkgdocs.julialang.org/v1/compatibility/#Version-specifier-format) correctly), which is not correct since LibCImGui.jl 1.89 is breaking but would still be allowed by that second bound.