### PR TITLE
Prepare v1.82.1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "CImGui"
 uuid = "5d785b6c-b76f-510e-a07c-3070796c7e87"
 authors = ["Yupei Qi <qiyupei@gmail.com>"]
-version = "1.82.0"
+version = "1.82.1"
 
 [deps]
 CEnum = "fa961155-64e5-5f13-b03f-caf6b980ea82"
@@ -15,10 +15,10 @@ Preferences = "21216c6a-2e73-6563-6e65-726566657250"
 [compat]
 CEnum = "0.4"
 CSyntax = "0.4"
-ImGuiGLFWBackend = "0.1, 0.2"
+ImGuiGLFWBackend = "0.1"
 ImGuiOpenGL2Backend = "0.1"
-ImGuiOpenGLBackend = "0.1, 0.2"
-LibCImGui = "~1.82, 1"
+ImGuiOpenGLBackend = "0.1"
+LibCImGui = "~1.82"
 Preferences = "1"
 julia = "1.6"
 

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,3 +1,6 @@
 [deps]
 CImGui = "5d785b6c-b76f-510e-a07c-3070796c7e87"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+
+[compat]
+Documenter = "1"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -4,7 +4,6 @@ using Documenter
 makedocs(;
     modules=[CImGui],
     authors="Yupei Qi <qiyupei@gmail.com>",
-    repo="https://github.com/Gnimuc/CImGui.jl/blob/{commit}{path}#L{line}",
     sitename="CImGui.jl",
     format=Documenter.HTML(;
         prettyurls=get(ENV, "CI", "false") == "true",

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -9,11 +9,12 @@ makedocs(;
         prettyurls=get(ENV, "CI", "false") == "true",
         canonical="https://Gnimuc.github.io/CImGui.jl",
         assets=String[],
+        size_threshold=400000
     ),
     pages=[
        "Introduction" => "index.md",
        "API Reference" => "api.md",
-    ],
+    ]
 )
 
 deploydocs(;

--- a/examples/demo_layout.jl
+++ b/examples/demo_layout.jl
@@ -316,7 +316,7 @@ function ShowDemoWindowLayout()
         if CImGui.ListBoxHeader("List", size)
             CImGui.Selectable("Selected", true)
             CImGui.Selectable("Not Selected", false)
-            CImGui.ListBoxFooter()
+            CImGui.EndListBox()
         end
 
         CImGui.TreePop()

--- a/src/wrapper.jl
+++ b/src/wrapper.jl
@@ -2150,7 +2150,6 @@ EndDragDropTarget() = igEndDragDropTarget()
 """
     GetDragDropPayload() -> Ptr{ImGuiPayload}
 Peek directly into the current payload from anywhere. May return C_NULL.
-Use [`IsDataType`](@ref) to test for the payload type.
 
 !!! note "BETA API"
     Missing Demo code. API may evolve.

--- a/src/wrapper.jl
+++ b/src/wrapper.jl
@@ -1614,11 +1614,11 @@ If the function return true, you can output elements then call [`EndListBox`](@r
 BeginListBox(label,size=ImVec2(0,0)) = igBeginListBox(label,size)
 
 """
-    ListBoxFooter()
+    EndListBox()
 Terminate the scrolling region.
 
 !!! note
-    Only call `ListBoxFooter()` if [`ListBoxHeader`](@ref) returned true!
+    Only call `EndListBox()` if [`BeginListBox`](@ref) returned true!
 """
 EndListBox() = igEndListBox()
 
@@ -1894,9 +1894,8 @@ GetColumnsCount() = igGetColumnsCount()
 # - 5. Call EndTable()
 """
     BeginTable(str_id, columns_count, flags = ImGuiTableFlags_(0), outer_size = ImVec2(0,0), inner_width = 0.0) -> Bool
-Begin a table entry. 
+Begin a table entry.
 """
-
 BeginTable(str_id, columns_count, flags = ImGuiTableFlags_(0), outer_size = ImVec2(0,0), inner_width = 0.0) = igBeginTable(str_id, columns_count, flags, outer_size, inner_width)
 
 """
@@ -1914,7 +1913,7 @@ TableNextRow(row_flags = ImGuiTableRowFlags_(0), min_row_height = 0.0) = igTable
 """
     TableNextColumn() -> Bool
 Append into the next column (or first column of next row if currently in last column). Return true when column is visible.
-"""                                                                                                                                    
+"""
 TableNextColumn() = igTableNextColumn()
 
 """


### PR DESCRIPTION
Copied from #104:
This is a patch release that fixes compat bounds for some dependencies, which were previously allowing newer-than-actually-compatible versions. See: https://github.com/Gnimuc/CImGui.jl/issues/100#issuecomment-1740640011

The main change here is to remove the unions from the bounds of ImGuiGLFWBackend.jl, ImGuiOpenGLBackend.jl, and LibCImGui.jl. e.g. `~1.82, 1` for LibCImGui.jl means that the allowed versions would be `[1.82 - 1.83) union [1 - 2)` (if I read the [docs](https://pkgdocs.julialang.org/v1/compatibility/#Version-specifier-format) correctly), which is not correct since LibCImGui.jl 1.89 is breaking but would still be allowed by that second bound.