### PR TITLE
Prepare v1.89.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "CImGui"
 uuid = "5d785b6c-b76f-510e-a07c-3070796c7e87"
 authors = ["Yupei Qi <qiyupei@gmail.com>"]
-version = "1.82.0"
+version = "1.89.0"
 
 [deps]
 CEnum = "fa961155-64e5-5f13-b03f-caf6b980ea82"
@@ -15,10 +15,10 @@ Preferences = "21216c6a-2e73-6563-6e65-726566657250"
 [compat]
 CEnum = "0.4"
 CSyntax = "0.4"
-ImGuiGLFWBackend = "0.1, 0.2"
+ImGuiGLFWBackend = "0.2"
 ImGuiOpenGL2Backend = "0.1"
-ImGuiOpenGLBackend = "0.1, 0.2"
-LibCImGui = "~1.82, 1"
+ImGuiOpenGLBackend = "0.2"
+LibCImGui = "~1.89"
 Preferences = "1"
 julia = "1.6"
 


### PR DESCRIPTION
New release with support for ImGui 1.89.4. Similarly to #105, this only bumps the compat bounds since all the 1.89 changes have already been merged (#87).