### PR TITLE
Update examples for v1.89

### DIFF
--- a/examples/app_custom_rendering.jl
+++ b/examples/app_custom_rendering.jl
@@ -33,14 +33,14 @@ function ShowExampleAppCustomRendering(p_open::Ref{Bool})
             th::Cfloat = (n == 0) ? 1.0 : thickness
             CImGui.AddCircle(draw_list, ImVec2(x+sz*0.5, y+sz*0.5), sz*0.5, col32, 6, th); x += sz + spacing; # hexagon
             CImGui.AddCircle(draw_list, ImVec2(x+sz*0.5, y+sz*0.5), sz*0.5, col32, 20, th); x += sz + spacing; # circle
-            CImGui.AddRect(draw_list, ImVec2(x, y), ImVec2(x+sz, y+sz), col32, 0.0, CImGui.ImDrawCornerFlags_All, th); x += sz + spacing;
-            CImGui.AddRect(draw_list, ImVec2(x, y), ImVec2(x+sz, y+sz), col32, 10.0, CImGui.ImDrawCornerFlags_All, th); x += sz + spacing;
-            CImGui.AddRect(draw_list, ImVec2(x, y), ImVec2(x+sz, y+sz), col32, 10.0, CImGui.ImDrawCornerFlags_TopLeft|CImGui.ImDrawCornerFlags_BotRight, th); x += sz + spacing;
+            CImGui.AddRect(draw_list, ImVec2(x, y), ImVec2(x+sz, y+sz), col32, 0.0, CImGui.ImDrawFlags_RoundCornersAll, th); x += sz + spacing;
+            CImGui.AddRect(draw_list, ImVec2(x, y), ImVec2(x+sz, y+sz), col32, 10.0, CImGui.ImDrawFlags_RoundCornersAll, th); x += sz + spacing;
+            CImGui.AddRect(draw_list, ImVec2(x, y), ImVec2(x+sz, y+sz), col32, 10.0, CImGui.ImDrawFlags_RoundCornersTopLeft | CImGui.ImDrawFlags_RoundCornersBottomRight, th); x += sz + spacing;
             CImGui.AddTriangle(draw_list, ImVec2(x+sz*0.5, y), ImVec2(x+sz,y+sz-0.5), ImVec2(x,y+sz-0.5), col32, th); x += sz + spacing;
             CImGui.AddLine(draw_list, ImVec2(x, y), ImVec2(x+sz,    y), col32, th); x += sz + spacing;  # horizontal line (note: drawing a filled rectangle will be faster!)
             CImGui.AddLine(draw_list, ImVec2(x, y), ImVec2(x,    y+sz), col32, th); x += spacing;       # vertical line (note: drawing a filled rectangle will be faster!)
             CImGui.AddLine(draw_list, ImVec2(x, y), ImVec2(x+sz, y+sz), col32, th); x += sz +spacing;   # diagonal line
-            CImGui.AddBezierCurve(draw_list, ImVec2(x, y), ImVec2(x+sz*1.3,y+sz*0.3), (x+sz-sz*1.3,y+sz-sz*0.3), ImVec2(x+sz, y+sz), col32, th);
+            CImGui.AddBezierCubic(draw_list, ImVec2(x, y), ImVec2(x+sz*1.3,y+sz*0.3), (x+sz-sz*1.3,y+sz-sz*0.3), ImVec2(x+sz, y+sz), col32, th);
             x = p.x + 4
             y += sz + spacing
         end
@@ -48,7 +48,7 @@ function ShowExampleAppCustomRendering(p_open::Ref{Bool})
         CImGui.AddCircleFilled(draw_list, ImVec2(x+sz*0.5, y+sz*0.5), sz*0.5, col32, 32); x += sz+spacing; # circle
         CImGui.AddRectFilled(draw_list, ImVec2(x, y), ImVec2(x+sz, y+sz), col32); x += sz+spacing;
         CImGui.AddRectFilled(draw_list, ImVec2(x, y), ImVec2(x+sz, y+sz), col32, 10.0); x += sz+spacing;
-        CImGui.AddRectFilled(draw_list, ImVec2(x, y), ImVec2(x+sz, y+sz), col32, 10.0, CImGui.ImDrawCornerFlags_TopLeft|CImGui.ImDrawCornerFlags_BotRight); x += sz+spacing;
+        CImGui.AddRectFilled(draw_list, ImVec2(x, y), ImVec2(x+sz, y+sz), col32, 10.0, CImGui.ImDrawFlags_RoundCornersTopLeft | CImGui.ImDrawFlags_RoundCornersBottomRight); x += sz+spacing;
         CImGui.AddTriangleFilled(draw_list, ImVec2(x+sz*0.5, y), ImVec2(x+sz,y+sz-0.5), ImVec2(x,y+sz-0.5), col32); x += sz+spacing;
         CImGui.AddRectFilled(draw_list, ImVec2(x, y), ImVec2(x+sz, y+thickness), col32); x += sz+spacing;          # horizontal line (faster than AddLine, but only handle integer thickness)
         CImGui.AddRectFilled(draw_list, ImVec2(x, y), ImVec2(x+thickness, y+sz), col32); x += spacing+spacing;     # vertical line (faster than AddLine, but only handle integer thickness)
@@ -81,7 +81,9 @@ function ShowExampleAppCustomRendering(p_open::Ref{Bool})
 
         adding_preview = false
         CImGui.InvisibleButton("canvas", canvas_size)
-        mouse_pos_in_canvas = ImVec2(CImGui.GetIO().MousePos.x - canvas_pos.x, CImGui.GetIO().MousePos.y - canvas_pos.y)
+        mouse_x = unsafe_load(CImGui.GetIO().MousePos.x)
+        mouse_y = unsafe_load(CImGui.GetIO().MousePos.y)
+        mouse_pos_in_canvas = ImVec2(mouse_x - canvas_pos.x, mouse_y - canvas_pos.y)
         if adding_line
             adding_preview = true
             push!(points, mouse_pos_in_canvas)

--- a/examples/demo.jl
+++ b/examples/demo.jl
@@ -7,7 +7,7 @@ using CImGui.ImGuiOpenGLBackend.ModernGL
 # using CImGui.ImGuiGLFWBackend.GLFW
 using CImGui.CSyntax
 
-# include(joinpath(@__DIR__, "demo_window.jl"))
+include(joinpath(@__DIR__, "demo_window.jl"))
 
 glfwDefaultWindowHints()
 glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 3)
@@ -86,7 +86,7 @@ try
         ImGuiGLFWBackend.new_frame(window_ctx)
         CImGui.NewFrame()
 
-        demo_open && @c CImGui.ShowDemoWindow(&demo_open)
+        demo_open && @c ShowJuliaDemoWindow(&demo_open)
 
         # show image example
         if CImGui.Begin("Image Demo")

--- a/examples/demo_layout.jl
+++ b/examples/demo_layout.jl
@@ -313,7 +313,7 @@ function ShowDemoWindowLayout()
         CImGui.Button("LEVERAGE\nBUZZWORD", size)
         CImGui.SameLine()
 
-        if CImGui.ListBoxHeader("List", size)
+        if CImGui.BeginListBox("List", size)
             CImGui.Selectable("Selected", true)
             CImGui.Selectable("Not Selected", false)
             CImGui.EndListBox()

--- a/examples/demo_misc.jl
+++ b/examples/demo_misc.jl
@@ -64,45 +64,51 @@ function ShowDemoWindowMisc()
             end
             CImGui.Text(@sprintf("Mouse wheel: %.1f", unsafe_load(io.MouseWheel)))
 
+            key_range = CImGui.ImGuiKey_NamedKey_BEGIN:CImGui.ImGuiKey_NamedKey_END - 1
+
             CImGui.Text("Keys down:")
-            for i = 0:511
-                dur = CImGui.c_get(io.KeysDownDuration, i)
+            for i = key_range
+                key_data = unsafe_load(CImGui.GetKeyData(CImGui.ImGuiKey(i)))
+                dur = key_data.DownDuration
                 dur ≥ 0 || continue
                 CImGui.SameLine()
                 txt = @sprintf "%d (%.02f secs)" i dur
                 CImGui.Text(txt)
             end
             CImGui.Text("Keys pressed:")
-            for i = 0:511
-                CImGui.IsKeyPressed(i) || continue
+            for i = key_range
+                CImGui.IsKeyPressed(CImGui.ImGuiKey(i)) || continue
                 CImGui.SameLine()
                 CImGui.Text("$i")
             end
             CImGui.Text("Keys release:")
-            for i = 0:511
-                CImGui.IsKeyReleased(i) || continue
+            for i = key_range
+                CImGui.IsKeyReleased(CImGui.ImGuiKey(i)) || continue
                 CImGui.SameLine()
                 CImGui.Text("$i")
             end
             CImGui.Text(@sprintf("Keys mods: %s%s%s%s", unsafe_load(io.KeyCtrl) ? "CTRL " : "", unsafe_load(io.KeyShift) ? "SHIFT " : "", unsafe_load(io.KeyAlt) ? "ALT " : "", unsafe_load(io.KeySuper) ? "SUPER " : ""))
 
+            navinput_range = CImGui.ImGuiKey_GamepadStart:CImGui.ImGuiKey_GamepadRStickDown
+
             CImGui.Text("NavInputs down:")
-            for i = 0:20
-                nav = CImGui.c_get(io.NavInputs, i)
-                nav > 0 || continue
+            for i = navinput_range
+                CImGui.IsKeyDown(CImGui.ImGuiKey(i)) || continue
                 CImGui.SameLine()
                 CImGui.Text(@sprintf("[%d] %.2f", i, nav))
             end
             CImGui.Text("NavInputs pressed:")
-            for i = 0:20
-                dur = CImGui.c_get(io.NavInputsDownDuration, i)
+            for i = navinput_range
+                key_data = unsafe_load(CImGui.GetKeyData(CImGui.ImGuiKey(i)))
+                dur = key_data.DownDuration
                 dur == 0.0 || continue
                 CImGui.SameLine()
                 CImGui.Text("[$i]")
             end
             CImGui.Text("NavInputs duration:")
-            for i = 0:20
-                dur = CImGui.c_get(io.NavInputsDownDuration, i)
+            for i = navinput_range
+                key_data = unsafe_load(CImGui.GetKeyData(CImGui.ImGuiKey(i)))
+                dur = key_data.DownDuration
                 dur ≥ 0.0 || continue
                 CImGui.SameLine()
                 CImGui.Text(@sprintf("[%d] %.2f", i, dur))

--- a/examples/demo_popups.jl
+++ b/examples/demo_popups.jl
@@ -91,8 +91,11 @@ function ShowDemoWindowPopups()
         @cstatic value = Cfloat(0.5) begin
             CImGui.Text(@sprintf("Value = %.3f (<-- right-click here)", value))
             if CImGui.BeginPopupContextItem("item context menu")
-                CImGui.Selectable("Set to zero") && (value = 0.0;)
-                CImGui.Selectable("Set to PI") && (value = 3.1415;)
+                # Note that we explicitly use Float32 literals, otherwise
+                # `value` would change type to Float64, which would cause an
+                # error when calling DragFloat(), which expects a Float32.
+                CImGui.Selectable("Set to zero") && (value = 0f0;)
+                CImGui.Selectable("Set to PI") && (value = 3.1415f0;)
                 CImGui.PushItemWidth(-1)
                 @c CImGui.DragFloat("##Value", &value, 0.1, 0.0, 0.0)
                 CImGui.PopItemWidth()

--- a/examples/demo_window.jl
+++ b/examples/demo_window.jl
@@ -48,12 +48,12 @@ no_nav = false
 no_background = false
 no_bring_to_front = false
 """
-    ShowDemoWindow(p_open::Ref{Bool})
-Demonstrate most Dear ImGui features.
+    ShowJuliaDemoWindow(p_open::Ref{Bool})
+Demonstrate most Dear ImGui features implemented using the Julia bindings.
 You may execute this function to experiment with the UI and understand what it does.
 You may then search for keywords in the code when you are interested by a specific feature.
 """
-global function ShowDemoWindow(p_open::Ref{Bool})
+global function ShowJuliaDemoWindow(p_open::Ref{Bool})
     # examples Apps (accessible from the "Examples" menu)
     # show_app_documents           && @c ShowExampleAppDocuments(&show_app_documents) # process the Document app next, as it may also use a DockSpace()
     show_app_main_menu_bar       && @c ShowExampleAppMainMenuBar(&show_app_main_menu_bar)

--- a/src/wrapper.jl
+++ b/src/wrapper.jl
@@ -2458,6 +2458,12 @@ Map ImGuiKey_* values into user's key index. == io.KeyMap[key]
 GetKeyIndex(imgui_key) = igGetKeyIndex(imgui_key)
 
 """
+    GetKeyData(imgui_key) -> Ptr{ImGuiKeyData}
+Get the key data for a specific key.
+"""
+GetKeyData(imgui_key) = igGetKeyData(imgui_key)
+
+"""
     IsKeyDown(user_key_index) -> Bool
 Is key being held. == io.KeysDown[user_key_index]. note that imgui doesn't know the semantic
 of each entry of io.KeysDown[]. Use your own indices/enums according to how your backend/engine


### PR DESCRIPTION
Overview of important changes:
- Renamed `ShowDemoWindow()` to `ShowJuliaDemoWindow()` to avoid confusion with the official demo, and use it by default in `examples/demo.jl`.
- Use `unsafe_load()` where appropriate.
- `ImDrawCornerFlags_*` -> `ImDrawFlags_RoundCorners*`: https://github.com/ocornut/imgui/blob/docking/imgui.h#L3515
- `AddBezierCurve()` -> `AddBezierCubic()`: https://github.com/ocornut/imgui/blob/docking/imgui.h#L2927
- Use explicit key ranges in `demo_misc.jl`:
  - https://github.com/ocornut/imgui/blob/docking/imgui.h#L949
  - https://github.com/ocornut/imgui/blob/docking/imgui.h#L2122

Fixes #76 :crossed_fingers: Tested by opening all of the sections and playing around with them.