### PR TITLE
Add support for setting the OpenGL version

### DIFF
--- a/docs/src/_changelog.md
+++ b/docs/src/_changelog.md
@@ -6,6 +6,10 @@ CurrentModule = CImGui
 This documents notable changes in CImGui.jl. The format is based on [Keep a
 Changelog](https://keepachangelog.com).
 
+## Unreleased
+
+### Added
+- The OpenGL version can now be set with [`render()`](@ref).
 
 ## [v2.0.0] - 2024-06-27
 

--- a/src/CImGui.jl
+++ b/src/CImGui.jl
@@ -126,6 +126,7 @@ Keyword arguments:
 - `engine=nothing`: An optional `ImGuiTestEngine.Engine` instance. If there are
   any tests registered with the test engine they will be queued and run
   automatically.
+- `opengl_version::VersionNumber=v"3.2"`: The OpenGL version to use.
 """
 function render(args...; kwargs...)
     _check_backend()


### PR DESCRIPTION
Also removed the explicit GLFW.Init()/GLFW.Terminate() calls since GLFW will do that automatically.

@Gnimuc, @sairus7, does this look reasonable? I tried to preserve the previous behaviour, except for defaulting to OpenGL 3.2 on non-OSX systems.