### PR TITLE
Pin the renderloop to thread 1 by default for safety

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,9 @@ jobs:
           arch: ${{ matrix.arch }}
       - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-buildpkg@v1
+      - name: Set the number of threads for the tests
+        run: |
+          echo "JULIA_NUM_THREADS=5,5" >> "$GITHUB_ENV"
       - uses: julia-actions/julia-runtest@v1
         with:
           prefix: xvfb-run -a -s '-screen 0 1024x768x24'

--- a/docs/src/_changelog.md
+++ b/docs/src/_changelog.md
@@ -6,6 +6,17 @@ CurrentModule = CImGui
 This documents notable changes in CImGui.jl. The format is based on [Keep a
 Changelog](https://keepachangelog.com).
 
+## Unreleased
+
+### Changed
+- **Breaking**: [`render()`](@ref) would previously run on whatever task and thread it was
+  called on, but with multiple threads that could cause issues if the task
+  migrated. It now defaults to being pinned to thread 1 and there's a couple new
+  keyword arguments, `spawn` and `wait`, to control the task pinning and wait
+  behaviour. This is technically breaking because any old code that set up
+  [`render()`](@ref) to run on a specific thread by task pinning won't work, to
+  get back the old behaviour pass `spawn=false`.
+
 ## [v2.3.0] - 2024-08-06
 
 ### Added

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -77,19 +77,9 @@ julia> ig.render(ctx; window_size=(360, 480), window_title="ImGui Window") do
        end
 ```
 
-Note that neither ImGui nor OpenGL are thread-safe, be aware of this if you
-start Julia with multiple threads using `--threads`. If you need to use multiple
-threads in an application, one option is to use the
-[threadpools](https://docs.julialang.org/en/v1/manual/multi-threading/#man-threadpools)
-introduced in Julia 1.9:
-```bash
-# Have an arbitrary number in the default pool, and 1 thread in the :interactive pool
-$ julia --threads=auto,1
-```
-
-Then start the render loop on the `:interactive` thread with `Threads.@spawn
-:interactive` and ensure that none of the other threads call GUI functions or
-modify the program state while your GUI code is being executing.
+Note that neither ImGui nor OpenGL are thread-safe, and because of this
+[`CImGui.render()`](@ref) will pin the renderloop to thread 1 by default (see the
+docstring for more information).
 
 ## Usage
 The API provided in this package is as close as possible to the original C++

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,6 +4,68 @@ using ImGuiTestEngine
 import ImGuiTestEngine as te
 import ModernGL, GLFW
 
+ig.set_backend(:GlfwOpenGL3)
+
+
+# Note: these tests may not be portable
+@testset "Setting renderloop threads" begin
+    if Threads.nthreads() == 1
+        @warn "Skipping the renderloop threads test because we're only running with one thread."
+        return
+    elseif Threads.nthreads(:default) == 0 || Threads.nthreads(:interactive) == 0
+        @warn "Skipping the renderloop threads test because one of the threadpools is empty."
+        return
+    end
+
+    ctx = ig.CreateContext()
+
+    # The default thread should be 1
+    tid = -1
+    ig.render(ctx) do
+        tid = Threads.threadid()
+        return :imgui_exit_loop
+    end
+    @test tid == 1
+
+    # Test pinning to a specific thread ID
+    ctx = ig.CreateContext()
+    ig.render(ctx; spawn=2) do
+        tid = Threads.threadid()
+        return :imgui_exit_loop
+    end
+    @test tid == 2
+
+    # Test pinning to a threadpool
+    ctx = ig.CreateContext()
+    ig.render(ctx; spawn=:interactive) do
+        tid = Threads.threadid()
+        return :imgui_exit_loop
+    end
+    @test tid in Threads.threadpooltids(:interactive)
+
+    # Test pinning to any thread, which should prioritize the interactive
+    # threadpool.
+    ctx = ig.CreateContext()
+    ret = ig.render(ctx; spawn=true) do
+        tid = Threads.threadid()
+        return :imgui_exit_loop
+    end
+    @test tid in Threads.threadpooltids(:interactive)
+
+    # When not spawning it should run on the current thread
+    ctx = ig.CreateContext()
+    tid = -1
+    ig.render(ctx; spawn=false) do
+        tid = Threads.threadid()
+        return :imgui_exit_loop
+    end
+    @test tid == Threads.threadid()
+
+    # It should return a Task when wait=false
+    ctx = ig.CreateContext()
+    ret = ig.render(Returns(:imgui_exit_loop), ctx; wait=false)
+    wait(ret)
+end
 
 include(joinpath(@__DIR__, "../demo/demo.jl"))
 


### PR DESCRIPTION
This should avoid folks accidentally shooting themselves in the foot if they start Julia with multiple threads.