### PR TITLE
Tear down GLMakie figures properly during precompilation

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "CImGui"
 uuid = "5d785b6c-b76f-510e-a07c-3070796c7e87"
 authors = ["Yupei Qi <qiyupei@gmail.com>"]
-version = "6.2.0"
+version = "6.2.1"
 
 [deps]
 CEnum = "fa961155-64e5-5f13-b03f-caf6b980ea82"

--- a/docs/src/_changelog.md
+++ b/docs/src/_changelog.md
@@ -6,6 +6,11 @@ CurrentModule = CImGui
 This documents notable changes in CImGui.jl. The format is based on [Keep a
 Changelog](https://keepachangelog.com).
 
+## [v6.2.1] - 2025-10-15
+
+### Fixed
+- Fixed teardown of GLMakie figures by the Makie extension ([#182]).
+
 ## [v6.2.0] - 2025-09-27
 
 ### Fixed

--- a/ext/GlfwOpenGLBackend.jl
+++ b/ext/GlfwOpenGLBackend.jl
@@ -65,7 +65,7 @@ ig._current_window(::Val{:GlfwOpenGL3}) = _window
 
 function renderloop(ui, ctx::Ptr{lib.ImGuiContext}, ::Val{:GlfwOpenGL3};
                     hotloading=true,
-                    on_exit=nothing,
+                    on_exit=Returns(nothing),
                     clear_color=Cfloat[0.45, 0.55, 0.60, 1.00],
                     window_size=(1280, 720),
                     window_title="CImGui",
@@ -192,11 +192,11 @@ function renderloop(ui, ctx::Ptr{lib.ImGuiContext}, ::Val{:GlfwOpenGL3};
     catch e
         @error "Error in CImGui $(ig._backend) renderloop!" exception=(e, catch_backtrace())
     finally
-        for func in vcat(ig._exit_handlers, isnothing(on_exit) ? [] : [on_exit])
+        for func in vcat(ig._exit_handlers, [on_exit])
             try
                 func()
             catch ex
-                @error "Error in exit handler!" exception=(ex, catch_backtrace())
+                @error "Error in CImGui.jl exit handler!" exception=(ex, catch_backtrace())
             end
         end
 

--- a/ext/MakieIntegration.jl
+++ b/ext/MakieIntegration.jl
@@ -35,6 +35,7 @@ const makie_context = Dict{ig.ImGuiID, ImMakieFigure}()
 function destroy_context()
     for imfigure in values(makie_context)
         empty!(imfigure.figure)
+        GLMakie.destroy!(imfigure.screen)
     end
 
     empty!(makie_context)
@@ -293,7 +294,11 @@ end
         ig.set_backend(:GlfwOpenGL3)
         ctx = ig.CreateContext()
 
-        ig.render(ctx; window_title="CImGui/Makie precompilation workload", opengl_version=v"3.3") do
+        # Note that we explicitly pass `on_exit=destroy_context` since
+        # __init__() doesn't run during precompilation.
+        ig.render(ctx; window_title="CImGui/Makie precompilation workload",
+                  opengl_version=v"3.3",
+                  on_exit=destroy_context) do
             ig.Begin("Foo")
             ig.MakieFigure("plot", f)
             ig.End()
@@ -301,7 +306,6 @@ end
             return :imgui_exit_loop
         end
 
-        destroy_context()
         ig._backend = nothing
     end
 end


### PR DESCRIPTION
Calling `destroy_context()` after the renderloop is bad because the renderloop will clean up the ImGui resources (including the OpenGL context) when it finishes.

Fixes #181.