### PR TITLE
Call test engine's per-frame post-swap hook so screen capture can advance

### DIFF
--- a/ext/GlfwOpenGLBackend.jl
+++ b/ext/GlfwOpenGLBackend.jl
@@ -182,6 +182,11 @@ function renderloop(ui, ctx::Ptr{lib.ImGuiContext}, ::Val{:GlfwOpenGL3};
                 @ccall jl_gc_safe_leave()::Int8
             end
 
+            # Advance test engine's screen-capture state.
+            if !isnothing(engine)
+                ig._post_swap(engine)
+            end
+
             if (unsafe_load(ig.GetIO().ConfigFlags) & lib.ImGuiConfigFlags_ViewportsEnable) == lib.ImGuiConfigFlags_ViewportsEnable
                 backup_current_context = GLFW.GetCurrentContext()
                 lib.igUpdatePlatformWindows()

--- a/src/CImGui.jl
+++ b/src/CImGui.jl
@@ -264,6 +264,7 @@ end
 function _test_engine_is_running end
 function _start_test_engine end
 function _show_test_window end
+function _post_swap end
 
 
 function __init__()


### PR DESCRIPTION
Companion to JuliaImGui/ImGuiTestEngine.jl#19; the test engine registers a method on this hook.