### PR TITLE
GL: texture filter kwarg; enable screenshot capture

### DIFF
--- a/ext/GlfwOpenGLBackend.jl
+++ b/ext/GlfwOpenGLBackend.jl
@@ -65,6 +65,65 @@ end
 _window::Union{Nothing, GLFW.Window} = nothing
 ig._current_window(::Val{:GlfwOpenGL3}) = _window
 
+# test engine drives screenshots through a backend-provided `ImGuiScreenCaptureFunc`:
+# bool (*)(ImGuiID viewport_id, int x, int y, int w, int h, unsigned int* pixels, void* user_data)
+#
+# It must write the framebuffer region (x, y, w, h) into `pixels` as RGBA8
+# capture tool works in ImGui display coordinates (logical pixels), so on a HiDPI display
+# the actual framebuffer is larger and we downsample
+function _capture_framebuffer(viewport_id::lib.ImGuiID, x::Cint, y::Cint, w::Cint, h::Cint,
+                              pixels::Ptr{Cuint}, user_data::Ptr{Cvoid})::Bool
+    (w <= 0 || h <= 0) && return true
+
+    window = _window
+    window === nothing && return false
+
+    # derive the logical->framebuffer scale
+    fb_w, fb_h = GLFW.GetFramebufferSize(window)
+    io = ig.GetIO()
+    display = unsafe_load(io.DisplaySize)
+    sx = fb_w / display.x
+    sy = fb_h / display.y
+
+    # The framebuffer region corresponding to the requested logical rect.
+    fx = round(Int, x * sx)
+    fw = round(Int, w * sx)
+    fh = round(Int, h * sy)
+    # GL's origin is bottom-left, so flip the rect's y to GL coordinates.
+    gl_y = fb_h - round(Int, (y + h) * sy)
+
+    # Read the front buffer, restoring the previously-bound read buffer after.
+    prev_read_buffer = Ref{GL.GLint}(0)
+    GL.glGetIntegerv(GL.GL_READ_BUFFER, prev_read_buffer)
+    GL.glReadBuffer(GL.GL_FRONT)
+    GL.glPixelStorei(GL.GL_PACK_ALIGNMENT, 1)
+
+    # glReadPixels returns rows bottom-to-top, fw wide, fh tall.
+    scratch = Vector{Cuint}(undef, fw * fh)
+    GC.@preserve scratch begin
+        GL.glReadPixels(fx, gl_y, fw, fh, GL.GL_RGBA, GL.GL_UNSIGNED_BYTE, pointer(scratch))
+    end
+    GL.glReadBuffer(prev_read_buffer[])
+
+    # Downsample (nearest) into the logical w×h output, flipping rows: GL rows are
+    # bottom-to-top, the tool wants top-to-bottom (the `fh -` does the flip).
+    S = reshape(scratch, fw, fh)
+    cols = clamp.(round.(Int, ((1:w) .- 0.5) .* sx), 0, fw - 1) .+ 1
+    rows = fh .- clamp.(round.(Int, ((1:h) .- 0.5) .* sy), 0, fh - 1)
+    out = unsafe_wrap(Array, pixels, (w, h))   # view the caller's buffer, no copy
+    out .= @view S[cols, rows]
+
+    return true
+end
+
+# @cfunction pointer should be built in __init__, not during precompilation
+_CAPTURE_CFN::Ptr{Cvoid} = C_NULL
+
+function __init__()
+    global _CAPTURE_CFN = @cfunction(_capture_framebuffer, Bool,
+                                     (lib.ImGuiID, Cint, Cint, Cint, Cint, Ptr{Cuint}, Ptr{Cvoid}))
+end
+
 function renderloop(ui, ctx::Ptr{lib.ImGuiContext}, ::Val{:GlfwOpenGL3};
                     hotloading=true,
                     on_exit=Returns(nothing),
@@ -113,6 +172,12 @@ function renderloop(ui, ctx::Ptr{lib.ImGuiContext}, ::Val{:GlfwOpenGL3};
     # Setup Platform/Renderer bindings
     lib.ImGui_ImplGlfw_InitForOpenGL(Ptr{lib.GLFWwindow}(window.handle), true)
     lib.ImGui_ImplOpenGL3_Init("#version $(glsl_version)")
+
+    # screen-capture function so the test engine can take screenshots
+    # here (not in ImGuiTestEngine) because the capture needs the GL context
+    if !isnothing(engine)
+        engine.IO.ScreenCaptureFunc = _CAPTURE_CFN
+    end
 
     try
         while !GLFW.WindowShouldClose(window)

--- a/ext/GlfwOpenGLBackend.jl
+++ b/ext/GlfwOpenGLBackend.jl
@@ -28,12 +28,12 @@ end
 
 const g_ImageTexture = Dict{Int, GL.GLuint}()
 
-function ig._create_image_texture(::Val{:GlfwOpenGL3}, image_width, image_height; format=GL.GL_RGBA, type=GL.GL_UNSIGNED_BYTE)
+function ig._create_image_texture(::Val{:GlfwOpenGL3}, image_width, image_height; format=GL.GL_RGBA, type=GL.GL_UNSIGNED_BYTE, filter=GL.GL_LINEAR)
     id = GL.GLuint(0)
     @c GL.glGenTextures(1, &id)
     GL.glBindTexture(GL.GL_TEXTURE_2D, id)
-    GL.glTexParameteri(GL.GL_TEXTURE_2D, GL.GL_TEXTURE_MIN_FILTER, GL.GL_LINEAR)
-    GL.glTexParameteri(GL.GL_TEXTURE_2D, GL.GL_TEXTURE_MAG_FILTER, GL.GL_LINEAR)
+    GL.glTexParameteri(GL.GL_TEXTURE_2D, GL.GL_TEXTURE_MIN_FILTER, filter)
+    GL.glTexParameteri(GL.GL_TEXTURE_2D, GL.GL_TEXTURE_MAG_FILTER, filter)
     GL.glPixelStorei(GL.GL_UNPACK_ROW_LENGTH, 0)
     GL.glTexImage2D(GL.GL_TEXTURE_2D, 0, format, GL.GLsizei(image_width), GL.GLsizei(image_height), 0, format, type, C_NULL)
     g_ImageTexture[id] = id

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -288,3 +288,99 @@ include(joinpath(@__DIR__, "../examples/makie_demo.jl"))
     makie_demo(; engine)
     te.DestroyContext(engine)
 end
+
+@testset "Screen capture" begin
+    # RGBA8 packing: byte 0 = R (low byte), matching IM_COL32(r,g,b,a) and
+    # glReadPixels(GL_RGBA, GL_UNSIGNED_BYTE).
+    rgba(r, g, b, a) = UInt32(r) | (UInt32(g) << 8) | (UInt32(b) << 16) | (UInt32(a) << 24)
+    RED   = rgba(255, 0, 0, 255)
+    GREEN = rgba(0, 255, 0, 255)
+    BLUE  = rgba(0, 0, 255, 255)
+    WHITE = rgba(255, 255, 255, 255)
+
+    window_size = (1280, 720)
+    ctx = ig.CreateContext()
+    engine = te.CreateContext(; exit_on_completion=true, show_test_window=false)
+
+    # Draw a fullscreen 4-quadrant solid-color pattern via the background draw
+    # list. Distinct colors per corner catch orientation/channel/DPI errors.
+    t = @register_test(engine, "Screen capture", "Quadrant pattern")
+    t.GuiFunc = () -> begin
+        dl = ig.GetBackgroundDrawList()
+        vp = ig.GetMainViewport()
+        pos = unsafe_load(vp.Pos)
+        sz = unsafe_load(vp.Size)
+        cx = pos.x + sz.x / 2
+        cy = pos.y + sz.y / 2
+        ig.AddRectFilled(dl, ig.ImVec2(pos.x, pos.y), ig.ImVec2(cx, cy), RED)                  # top-left
+        ig.AddRectFilled(dl, ig.ImVec2(cx, pos.y), ig.ImVec2(pos.x + sz.x, cy), GREEN)         # top-right
+        ig.AddRectFilled(dl, ig.ImVec2(pos.x, cy), ig.ImVec2(cx, pos.y + sz.y), BLUE)          # bottom-left
+        ig.AddRectFilled(dl, ig.ImVec2(cx, cy), ig.ImVec2(pos.x + sz.x, pos.y + sz.y), WHITE)  # bottom-right
+    end
+
+    # Results captured from inside the TestFunc coroutine.
+    result = Ref{Any}(nothing)
+
+    # The output image buffer; the capture tool fills Width/Height/Data.
+    imbuf = Ref(te.lib.ImGuiCaptureImageBuf(Cint(0), Cint(0), Ptr{Cuint}(C_NULL)))
+
+    t.TestFunc = () -> begin
+        GC.@preserve imbuf begin
+            # A known sub-rect of the screen, in logical (display) coordinates,
+            # centered on the screen center so its four quadrants land in the
+            # four screen-color quadrants.
+            rw, rh = 400f0, 300f0
+            cx, cy = window_size[1] / 2, window_size[2] / 2
+            rx, ry = cx - rw / 2, cy - rh / 2
+            rect = ig.ImRect(ig.ImVec2(rx, ry), ig.ImVec2(rx + rw, ry + rh))
+            args = Ref(te.lib.ImGuiCaptureArgs(
+                UInt32(te.lib.ImGuiCaptureFlags_Instant) | UInt32(te.lib.ImGuiCaptureFlags_NoSave),
+                te.lib.ImVector_ImGuiWindowPtr(Cint(0), Cint(0), Ptr{Ptr{ig.lib.ImGuiWindow}}(C_NULL)),
+                rect,
+                0f0,
+                ntuple(_ -> Cchar(0), 256),
+                Base.unsafe_convert(Ptr{te.lib.ImGuiCaptureImageBuf}, imbuf),
+                Cint(0), Cint(0),
+                ig.ImVec2(0f0, 0f0),
+            ))
+
+            # Drives PostSwap -> CaptureUpdate -> ScreenCaptureFunc. The render
+            # loop advances frames while this yields.
+            ok = te.CaptureScreenshot(engine, args)
+
+            b = imbuf[]
+            W, H = Int(b.Width), Int(b.Height)
+            # Sample the four quadrant centers of the captured sub-rect. The
+            # sub-rect is centered on the screen center, so each of its quadrants
+            # lands in one of the screen quadrants.
+            sample(px, py) = unsafe_load(b.Data, py * W + px + 1)
+            result[] = (;
+                ok, W, H,
+                tl = sample(W ÷ 4, H ÷ 4),
+                tr = sample(3W ÷ 4, H ÷ 4),
+                bl = sample(W ÷ 4, 3H ÷ 4),
+                br = sample(3W ÷ 4, 3H ÷ 4),
+            )
+        end
+    end
+
+    # The render loop's test-engine startup queues all registered tests.
+    ig.render(ctx; engine, window_title="CImGui capture test", window_size) do
+        return nothing
+    end
+
+    @test result[] !== nothing
+    r = result[]
+    # Capture must succeed
+    @test r.ok
+    # Buffer is sized to the requested rect (logical pixels).
+    @test r.W == 400
+    @test r.H == 300
+    # Orientation + channel order + DPI: each quadrant has the expected color.
+    @test r.tl == RED
+    @test r.tr == GREEN
+    @test r.bl == BLUE
+    @test r.br == WHITE
+
+    te.DestroyContext(engine)
+end


### PR DESCRIPTION
- add filter kwarg to _create_image_texture (hope make sense, even though it's underscored function)
- set ScreenCaptureFunc if testengine is loaded, so that screenshot capturing doesn't require user to implement it